### PR TITLE
Get config from self after build_config()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,11 +256,12 @@ impl Service<Uri> for AlpnConnector {
             }
         };
 
-        let config = self.config.clone();
-        if config.is_none() {
-            self.build_config()
-        }
-        let config = config.unwrap();
+        let config = if let Some(config) = self.config.as_ref() {
+            config.clone()
+        } else {
+            self.build_config();
+            self.config.clone().unwrap()
+        };
 
         let fut = async move {
             let socket = Self::resolve(dst).await?;


### PR DESCRIPTION
# Description

`build_config()` mutates `self`. This pull request ensures that the config is cloned from `self` after `build_config()` is called.

Resolves #13

## How Has This Been Tested?

Used the forked code in production, and confirmed that this is now working as expected.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update